### PR TITLE
IO - Locations - Fix return type indicator

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,7 +41,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            python-version: [3.9, '3.10', '3.11']
+            python-version: [3.9, '3.10', '3.11', '3.12']
 
         steps:
           - uses: actions/checkout@v2

--- a/insitupy/io/locations.py
+++ b/insitupy/io/locations.py
@@ -1,6 +1,7 @@
 import logging
-import utm
 from typing import Tuple
+
+import utm
 
 from .yaml_codes import YamlCodes
 
@@ -99,7 +100,7 @@ class LocationManager:
         return lat, lon, easting, northing
 
     @classmethod
-    def parse_utm_epsg(cls, headers: dict) -> int | None:
+    def parse_utm_epsg(cls, headers: dict) -> int:
         # TODO: headers based utm?
         if YamlCodes.UTM_ZONE in headers.keys():
             utm_zone = int(

--- a/insitupy/io/locations.py
+++ b/insitupy/io/locations.py
@@ -111,3 +111,7 @@ class LocationManager:
             return int(f"{YamlCodes.UTM_EPSG_PREFIX}{utm_zone}")
         elif YamlCodes.EPSG in headers.keys():
             return int(headers[YamlCodes.EPSG])
+        else:
+            raise ValueError(
+                f"Could not find UTM keys in headers: {headers.keys()}"
+            )


### PR DESCRIPTION
Fix the return type indicator for method 'parse_utm_epsg'. 'None' was never returned and it is always an int.

Also adding 3.12 to the CI since that is the version I am currently using to develop locally.