### PR TITLE
Campaigns - Remove IGNORE entry from SnowEx primary yaml

### DIFF
--- a/insitupy/campaigns/snowex/snowexprimaryvariables.yaml
+++ b/insitupy/campaigns/snowex/snowexprimaryvariables.yaml
@@ -14,19 +14,6 @@ INSTRUMENT:
   - measurement_tool
   - instrument
   match_on_code: true
-IGNORE:
-  auto_remap: false
-  code: ignore
-  description: Ignore this
-  map_from:
-  - original_index
-  - id
-  - freq_mhz
-  - camera
-  - avgvelocity
-  - equipment
-  - version_number
-  match_on_code: true
 COMMENTS:
   auto_remap: false
   code: comments


### PR DESCRIPTION
Adding an entry with the IGNORE key will result in any entry in the map_from element to not be recognized if the parent key is after the letter I in overwrite files. Simplest solution is to not have this as part of the parent package and always make the user specify this through a custom YAML.